### PR TITLE
Bump minimum supported to Julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ GLPK = "0.15"
 Ipopt = "0.8"
 JuMP = "0.22"
 MathOptInterface = "0.10.3"
-julia = "1"
+julia = "1.6"
 
 [extras]
 GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"


### PR DESCRIPTION
Julia 1.0 is untested, and in fact will not work because this package contains a lot of calls like `isnothing` which are not defined in 1.0.

The simplest solution is just to restrict Pavito to 1.6 and later. It's going to be the new LTS anyway.