### PR TITLE
Allow returning almost feasible solution

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -336,7 +336,7 @@ end
 MOI.get(::Optimizer, ::MOI.DualStatus) = MOI.NO_SOLUTION
 
 function MOI.get(model::Optimizer, ::MOI.ResultCount)
-    return MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT ? 1 : 0
+    return MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION ? 0 : 1
 end
 
 # utilities:


### PR DESCRIPTION
Otherwise, we say the status is `ALMOST_LOCALLY_SOLVED` but we can't get it through JuMP because of the `ResultCount`

This bug was detected in https://github.com/dionysos-dev/Dionysos.jl/issues/233