### PR TITLE
Fix fixing int variable constrained to Interval set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,8 @@ Ipopt = "0.8, 0.9, 1"
 JuMP = "0.22, 0.23, 1"
 MINLPTests = "0.5"
 MathOptInterface = "0.10.3, 1"
+Printf = "<0.0.1, 1.6"
+Test = "<0.0.1, 1.6"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
MOI v1.25.1 fixes a bug that allowed multiple bound constraints if the bound was bridged. This was hiding a bug in Pavito in that we didn't delete `x-in-Interval` constraints if one existed.
 
x-ref https://github.com/jump-dev/MathOptInterface.jl/pull/2399